### PR TITLE
[EUCAIM-99] Updating datasets in FDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,13 @@ Options:
 Usage: img2catalog fdp [OPTIONS]
 
 Options:
-  -c, --catalog URIREF  Catalog URI of FDP
+  -s, --sparql URIREF   URL of SPARQL endpoint of FDP, used for querying which
+                        dataset to update
+  -c, --catalog URIREF  Catalog URI where datasets will be placed in
+                        [required]
   -p, --password TEXT   Password of FDP to push to  [required]
   -u, --username TEXT   Username of FDP to push to  [required]
-  -f, --fdp TEXT        URL of FDP to push to  [required]
+  -f, --fdp TEXT        URL of FDP to push datasets to  [required]
   --help                Show this message and exit.
 
 ```
@@ -135,7 +138,6 @@ we are open to any additions.
 
 Currently, only title, description, keywords and PI are set as well as title, description and
 publisher of the catalogue. There is no Distribution, Dataset Series or anything else.
-Datasets can be pushed to a FAIR Data Point, but not updated - this may result in duplicates.
 The language of the fields also is not set.
 
 ## Disclaimer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "click >= 8.0.0",
   "click-option-group~=0.5.6",
   "sempyro >=1.2.1",
+  "sparqlwrapper~=2.0",
 ]
 
 [project.entry-points]

--- a/src/img2catalog/cli_app.py
+++ b/src/img2catalog/cli_app.py
@@ -208,13 +208,19 @@ def output_dcat(ctx: click.Context, output: click.Path, format: str):
         print(g.serialize(format=format))
 
 
-@click.option("-f", "--fdp", envvar=FDP_SERVER_ENV, type=str, required=True, help="URL of FDP to push to")
+@click.option("-f", "--fdp", envvar=FDP_SERVER_ENV, type=str, required=True, help="URL of FDP to push datasets to")
 @click.option("-u", "--username", envvar=FDP_USER_ENV, type=str, required=True, help="Username of FDP to push to")
 @click.option("-p", "--password", envvar=FDP_PASS_ENV, type=str, required=True, help="Password of FDP to push to")
 @click.option(
     "-c", "--catalog", default=None, type=URIRef, help="Catalog URI where datasets will be placed in", required=True
 )
-@click.option("-s", "--sparql", default=None, type=URIRef, help=" URL of SPARQL endpoint of FDP, used to ")
+@click.option(
+    "-s",
+    "--sparql",
+    default=None,
+    type=URIRef,
+    help=" URL of SPARQL endpoint of FDP, used for querying which dataset to update",
+)
 @cli_click.command(name="fdp")
 @click.pass_context
 def output_fdp(ctx: click.Context, fdp: str, username: str, password: str, catalog: URIRef, sparql: str):

--- a/src/img2catalog/cli_app.py
+++ b/src/img2catalog/cli_app.py
@@ -1,11 +1,13 @@
 import logging
-from pathlib import Path, PurePath
-from typing import Dict
+from pathlib import Path
 
 import click
+import xnat
 from click_option_group import MutuallyExclusiveOptionGroup, optgroup
 from rdflib import URIRef
 
+from img2catalog import log
+from img2catalog.__about__ import __version__
 from img2catalog.configmanager import load_img2catalog_configuration
 
 # from xnat.client.helpers import xnatpy_login_options, connect_cli
@@ -19,17 +21,6 @@ from img2catalog.const import (
     XNATPY_HOST_ENV,
 )
 from img2catalog.fdpclient import FDPClient, FDPSPARQLClient
-
-# Python < 3.11 does not have tomllib, but tomli provides same functionality
-try:
-    import tomllib
-except ModuleNotFoundError:
-    import tomli as tomllib
-
-import xnat
-
-from img2catalog import log
-from img2catalog.__about__ import __version__
 from img2catalog.xnat_parser import xnat_to_DCATDataset, xnat_to_FDP, xnat_to_RDF
 
 logger = logging.getLogger(__name__)

--- a/src/img2catalog/fdpclient.py
+++ b/src/img2catalog/fdpclient.py
@@ -74,7 +74,7 @@ class FDPClient(BasicAPIClient):
         password : str
             password for authentication
         """
-        self.base_url = base_url
+        self.base_url = base_url.rstrip('/')
         self.username = username
         # Don't store password for security reasons (might show up in a stack trace or something)
         # self.password = password

--- a/src/img2catalog/fdpclient.py
+++ b/src/img2catalog/fdpclient.py
@@ -5,7 +5,6 @@ from urllib.parse import urljoin, urlparse
 import requests
 from rdflib import DCAT, DCTERMS, RDF, Graph, URIRef
 from requests import HTTPError, Response
-
 from sempyro.vcard import VCARD
 
 logger = logging.getLogger(__name__)
@@ -38,23 +37,6 @@ class BasicAPIClient:
             raise e
 
         return response
-
-        # Commented this out, as I don't mind having the exceptions go through the stack
-        # except requests.exceptions.HTTPError as e:
-        #     logger.error(e)
-        #     if response is not None:
-        #         logger.error(response.text)
-        #     # sys.exit(1)
-        # except requests.exceptions.ConnectionError as e:
-        #     logger.error(e)
-        #     # sys.exit(1)
-        # except requests.exceptions.Timeout as e:
-        #     logger.error(e)
-        #     # sys.exit(1)
-        # except requests.exceptions.RequestException as e:
-        #     logger.error(e)
-        #     # sys.exit(1)
-        # except Exception as e:
 
     def get(self, path: str, params: Dict = None) -> Response:
         return self._call_method("GET", path, params=params)

--- a/src/img2catalog/fdpclient.py
+++ b/src/img2catalog/fdpclient.py
@@ -340,13 +340,12 @@ def rewrite_graph_subject(g: Graph, oldsubject: Union[str, URIRef], newsubject: 
     Parameters
     ----------
     g : Graph
-        Reference graph in which the subject will be in-place to be replaced
+        Reference graph in which the subject will be replaced, in-place
     oldsubject : str, URIRef
         The old subject which is to be replaced
-    newsubject : str
-        New subject
+    newsubject : str, URIRef
+        New subject which will replace the old subject
     """
     for s, p, o in g.triples((URIRef(oldsubject), None, None)):
-        print(s, p, o)
         g.add((URIRef(newsubject), p, o))
         g.remove((s, p, o))

--- a/src/img2catalog/fdpclient.py
+++ b/src/img2catalog/fdpclient.py
@@ -118,7 +118,7 @@ class FDPClient(BasicAPIClient):
         self._update_session_headers()
 
     def post_serialized(self, resource_type: str, metadata: "Graph") -> requests.Response:
-        """Serializes and posts a graph to an FDP
+        """Serializes and POSTs a graph to an FDP
 
         Parameters
         ----------
@@ -136,6 +136,26 @@ class FDPClient(BasicAPIClient):
         path = f"{self.base_url}/{resource_type}"
         logger.debug("Posting metadata to %s", path)
         response = self.post(path=path, data=metadata.serialize(format="turtle"))
+        return response
+
+    def update_serialized(self, resource_uri: str, metadata: "Graph") -> requests.Response:
+        """Serializes and updates (PUTs) a graph on an FDP
+
+        Parameters
+        ----------
+        resource_uri : str
+            URI to update
+        metadata : Graph
+            The graph with metadata to be pusshed
+
+        Returns
+        -------
+        requests.Response
+            The response from the FDP
+        """
+        self._change_content_type("text/turtle")
+        logger.debug("Putting metadata to %s", resource_uri)
+        response = self.update(path=resource_uri, data=metadata.serialize(format="turtle"))
         return response
 
     def get_data(self, path: str) -> requests.Response:

--- a/src/img2catalog/fdpclient.py
+++ b/src/img2catalog/fdpclient.py
@@ -78,9 +78,10 @@ class FDPClient(BasicAPIClient):
         self.username = username
         # Don't store password for security reasons (might show up in a stack trace or something)
         # self.password = password
+        logger.debug("Logging into FDP %s with user %s", self.base_url, self.username)
         self.__token = self.login_fdp(username, password)
         headers = self.get_headers()
-        super().__init__(base_url, headers)
+        super().__init__(self.base_url, headers)
 
     def login_fdp(self, username: str, password: str) -> str:
         """Logs in to a Fair Data Point and retrieves a JWT token

--- a/src/img2catalog/fdpclient.py
+++ b/src/img2catalog/fdpclient.py
@@ -5,8 +5,8 @@ from urllib.parse import urljoin, urlparse
 import requests
 from rdflib import DCAT, DCTERMS, RDF, Graph, URIRef
 from requests import HTTPError, Response
-from SPARQLWrapper import SPARQLWrapper, JSON
 from sempyro.vcard import VCARD
+from SPARQLWrapper import JSON, SPARQLWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -258,7 +258,7 @@ WHERE {{
     ?subject dcterms:isPartOf <{catalog}> .
 }}"""
         self.sparql.setQuery(query)
-        results = self.sparql.queryAndConvert()['results']['bindings']
+        results = self.sparql.queryAndConvert()["results"]["bindings"]
 
         if len(results) == 0:
             # No result found

--- a/src/img2catalog/xnat_parser.py
+++ b/src/img2catalog/xnat_parser.py
@@ -5,16 +5,14 @@ import re
 from typing import Dict, List, Tuple, Union
 
 from rdflib import DCAT, DCTERMS, FOAF, Graph, URIRef
+from sempyro.dcat import DCATCatalog, DCATDataset
+from sempyro.vcard import VCARD, VCard
 
 from tqdm import tqdm
 from xnat.core import XNATBaseObject
 from xnat.session import XNATSession
 
 from img2catalog.fdpclient import FDPClient, prepare_dataset_graph_for_fdp
-
-
-from sempyro.vcard import VCard, VCARD
-from sempyro.dcat import DCATCatalog, DCATDataset
 
 logger = logging.getLogger(__name__)
 

--- a/src/img2catalog/xnat_parser.py
+++ b/src/img2catalog/xnat_parser.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from xnat.core import XNATBaseObject
 from xnat.session import XNATSession
 
-from img2catalog.fdpclient import FDPClient, prepare_dataset_graph_for_fdp
+from img2catalog.fdpclient import FDPClient, FDPSPARQLClient, add_or_update_dataset, prepare_dataset_graph_for_fdp
 
 logger = logging.getLogger(__name__)
 
@@ -158,7 +158,9 @@ def xnat_to_RDF(session: XNATSession, config: Dict) -> Graph:
     return export_graph
 
 
-def xnat_to_FDP(session: XNATSession, config: Dict, catalog_uri: URIRef, fdpclient: FDPClient) -> None:
+def xnat_to_FDP(
+    session: XNATSession, config: Dict, catalog_uri: URIRef, fdpclient: FDPClient, sparqlclient: FDPSPARQLClient = None
+) -> None:
     """Pushes DCAT-AP compliant Datasets to FDP
 
     Parameters
@@ -167,6 +169,12 @@ def xnat_to_FDP(session: XNATSession, config: Dict, catalog_uri: URIRef, fdpclie
         An XNATSession of the XNAT instance that is going to be queried
     config : Dict
         A dictionary containing the configuration of img2catalog
+    catalog_uri : URIRef
+        URI of the catalog in which the datasets will be placed
+    fdpclient : FDPClient
+        An instance of FDPClient of the FDP where the datasets will be put
+    sparqlclient : FDPSPARQLClient, optional
+        An instance of FDPSPARQLClient which can be used for updating existing datasts, by default None
 
     Returns
     -------
@@ -179,7 +187,10 @@ def xnat_to_FDP(session: XNATSession, config: Dict, catalog_uri: URIRef, fdpclie
         dataset_graph = dataset.to_graph(subject)
         prepare_dataset_graph_for_fdp(dataset_graph, catalog_uri)
         logger.debug("Going to push %s to FDP", dataset.title)
-        fdpclient.create_and_publish("dataset", dataset_graph)
+        try:
+            add_or_update_dataset(dataset_graph, fdpclient, dataset.identifier[0], catalog_uri, sparqlclient)
+        except Exception as e:
+            logger.warn("Error pushing dataset to FDP: %s", e)
 
 
 def xnat_list_datasets(session: XNATSession, config: Dict) -> List[DCATDataset]:

--- a/src/img2catalog/xnat_parser.py
+++ b/src/img2catalog/xnat_parser.py
@@ -71,6 +71,8 @@ def xnat_to_DCATDataset(project: XNATBaseObject, config: Dict) -> Tuple[DCATData
     if error_list:
         raise XNATParserError("Errors encountered during the parsing of XNAT.", error_list=error_list)
 
+    project_uri = project.external_uri()
+
     creator_vcard = [
         VCard(
             full_name=[f"{project.pi.title or ''} {project.pi.firstname} {project.pi.lastname}".strip()],
@@ -83,6 +85,7 @@ def xnat_to_DCATDataset(project: XNATBaseObject, config: Dict) -> Tuple[DCATData
         "description": [project.description],
         "creator": creator_vcard,
         "keyword": keywords,
+        "identifier": [project_uri],
     }
 
     contact_point_vcard = [contact_point_vcard_from_config(config)]

--- a/src/img2catalog/xnat_parser.py
+++ b/src/img2catalog/xnat_parser.py
@@ -94,7 +94,7 @@ def xnat_to_DCATDataset(project: XNATBaseObject, config: Dict) -> Tuple[DCATData
 
     project_dataset = DCATDataset(**dataset_dict)
 
-    return project_dataset, URIRef(project.external_uri())
+    return project_dataset, URIRef(project_uri)
 
 
 def xnat_to_DCATCatalog(session: XNATSession, config: Dict) -> DCATCatalog:

--- a/tests/references/empty_xnat.ttl
+++ b/tests/references/empty_xnat.ttl
@@ -2,7 +2,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://xnat.bmia.nl> a dcat:Catalog ;
+<https://example.com> a dcat:Catalog ;
     dcterms:title "Example XNAT catalog" ;
     dcterms:description "This is an example XNAT catalog description" .
 

--- a/tests/references/minimal_catalog_dataset.ttl
+++ b/tests/references/minimal_catalog_dataset.ttl
@@ -1,11 +1,11 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
-<https://example.com/catalog> a dcat:Catalog ;
-    dcterms:description "Test description" ;
-    dcterms:title "Test catalog" ;
-    dcat:dataset <http://example.com/dataset> .
+<https://example.com> a dcat:Catalog ;
+    dcterms:title "Example XNAT catalog" ;
+    dcterms:description "This is an example XNAT catalog description" ;
+    dcat:dataset <https://example.com/dataset> .
 
-<http://example.com/dataset> a dcat:Dataset ;
+<https://example.com/dataset> a dcat:Dataset ;
     dcterms:description "test description" ;
     dcterms:title "test project" .

--- a/tests/references/no_contact_email.ttl
+++ b/tests/references/no_contact_email.ttl
@@ -8,7 +8,7 @@
             vcard:fn "prof. Albus Dumbledore" ;
             vcard:hasUID <http://example.com> ] ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
-    dcterms:identifier "test_img2catalog"^^xsd:token ;
+    dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
     dcterms:temporal [ a dcterms:PeriodOfTime ] ;
     dcterms:title "Basic test project to test the img2catalog" ;
     dcat:keyword "dcat",

--- a/tests/references/no_contactpoint.ttl
+++ b/tests/references/no_contactpoint.ttl
@@ -8,7 +8,7 @@
             vcard:fn "prof. Albus Dumbledore" ;
             vcard:hasUID <http://example.com> ] ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
-    dcterms:identifier "test_img2catalog"^^xsd:token ;
+    dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
     dcterms:temporal [ a dcterms:PeriodOfTime ] ;
     dcterms:title "Basic test project to test the img2catalog" ;
     dcat:keyword "dcat",

--- a/tests/references/no_keyword.ttl
+++ b/tests/references/no_keyword.ttl
@@ -7,6 +7,7 @@
     dcterms:creator [ a vcard:VCard ;
             vcard:fn "prof. Albus Dumbledore" ;
             vcard:hasUID <http://example.com/> ] ;
+    dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
     dcterms:title "Basic test project to test the img2catalog" ;
     dcat:contactPoint [ a vcard:VCard ;

--- a/tests/references/no_keyword.ttl
+++ b/tests/references/no_keyword.ttl
@@ -10,6 +10,7 @@
     dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
     dcterms:title "Basic test project to test the img2catalog" ;
+    dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
     dcat:contactPoint [ a vcard:VCard ;
             vcard:fn "Example Data Management office" ;
             vcard:hasEmail <mailto:datamanager@example.com> ;

--- a/tests/references/valid_project.ttl
+++ b/tests/references/valid_project.ttl
@@ -7,6 +7,7 @@
             v:fn "prof. Albus Dumbledore" ;
             v:hasUID <http://example.com/> ] ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
+    dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
     dcterms:title "Basic test project to test the img2catalog" ;
     dcat:keyword "dcat",
         "demo",

--- a/tests/references/valid_project.ttl
+++ b/tests/references/valid_project.ttl
@@ -9,6 +9,7 @@
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
     dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
     dcterms:title "Basic test project to test the img2catalog" ;
+    dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
     dcat:keyword "dcat",
         "demo",
         "test" ;

--- a/tests/references/valid_project_subject_replaced.ttl
+++ b/tests/references/valid_project_subject_replaced.ttl
@@ -1,0 +1,18 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix v: <http://www.w3.org/2006/vcard/ns#> .
+
+<http://example.com/newsubject> a dcat:Dataset ;
+    dcterms:creator [ a v:VCard ;
+            v:fn "prof. Albus Dumbledore" ;
+            v:hasUID <http://example.com/> ] ;
+    dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
+    dcterms:title "Basic test project to test the img2catalog" ;
+    dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
+    dcat:keyword "dcat",
+        "demo",
+        "test" ;
+    dcat:contactPoint [ a v:VCard ;
+            v:fn "Example Data Management office" ;
+            v:hasEmail <mailto:datamanager@example.com> ;
+            v:hasUID <http://example.com/>  ] .

--- a/tests/test_cliapp.py
+++ b/tests/test_cliapp.py
@@ -316,13 +316,6 @@ def test_output_project_file(
         ["--verbose", "-s", "http://example.com", "project", "test_project", "-o", "test_project.xml", "-f", "xml"],
     )
 
-    result_graph = empty_graph.parse(source="test_project.xml", format="xml")
-    reference_graph = empty_graph.parse(source=pathlib.Path(__file__).parent / "references" / "mock_dataset.ttl")
-
-    # Verify known output
-    assert to_isomorphic(reference_graph) == to_isomorphic(result_graph)
-
-    # Make sure right functions are called
     connect.assert_called_once_with(server="http://example.com", user=ANY, password=ANY)
     xnat_to_DCATDataset.assert_called_with("test_project", ANY)
     connect.return_value.__enter__.return_value.projects.__getitem__.assert_called_once_with("test_project")

--- a/tests/test_cliapp.py
+++ b/tests/test_cliapp.py
@@ -1,6 +1,6 @@
 import pathlib
 import sys
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 from rdflib import DCAT, DCTERMS, Graph, URIRef

--- a/tests/test_cliapp.py
+++ b/tests/test_cliapp.py
@@ -49,8 +49,6 @@ def test_cli_connect(xnat_to_RDF, connect, empty_graph, isolated_cli_runner):
     # Run isolated (to keep log files safe)
     result = isolated_cli_runner.invoke(cli_click, ["--server", "http://example.com", "--verbose", "dcat"])
 
-    print(result.output)
-
     connect.assert_called_once_with(server="http://example.com", user=None, password=None)
     xnat_to_RDF.assert_called_once()
 

--- a/tests/test_cliapp.py
+++ b/tests/test_cliapp.py
@@ -316,6 +316,13 @@ def test_output_project_file(
         ["--verbose", "-s", "http://example.com", "project", "test_project", "-o", "test_project.xml", "-f", "xml"],
     )
 
+    result_graph = empty_graph.parse(source="test_project.xml", format="xml")
+    reference_graph = empty_graph.parse(source=pathlib.Path(__file__).parent / "references" / "mock_dataset.ttl")
+
+    # Verify known output
+    assert to_isomorphic(reference_graph) == to_isomorphic(result_graph)
+
+    # Make sure right functions are called
     connect.assert_called_once_with(server="http://example.com", user=ANY, password=ANY)
     xnat_to_DCATDataset.assert_called_with("test_project", ANY)
     connect.return_value.__enter__.return_value.projects.__getitem__.assert_called_once_with("test_project")

--- a/tests/test_cliapp.py
+++ b/tests/test_cliapp.py
@@ -5,8 +5,8 @@ from unittest.mock import ANY, MagicMock, Mock, patch
 import pytest
 from rdflib import DCAT, DCTERMS, Graph, URIRef
 from rdflib.compare import to_isomorphic
-from sempyro.vcard import VCARD
 from sempyro.dcat.dcat_dataset import DCATDataset
+from sempyro.vcard import VCARD
 
 from img2catalog.cli_app import cli_click, load_img2catalog_configuration
 from img2catalog.const import XNAT_HOST_ENV, XNAT_PASS_ENV, XNAT_USER_ENV, XNATPY_HOST_ENV
@@ -35,7 +35,7 @@ def toml_patch_target():
 
 @pytest.fixture()
 def dummy_dcat_dataset():
-    d = DCATDataset(title=['test project'], description=['test description'])
+    d = DCATDataset(title=["test project"], description=["test description"])
     return d
 
 

--- a/tests/test_dcat_serializer.py
+++ b/tests/test_dcat_serializer.py
@@ -51,13 +51,13 @@ def config():
 
 @pytest.fixture()
 def mock_catalog():
-    catalog = DCATCatalog(title=['Test catalog'], description=['Test description'])
+    catalog = DCATCatalog(title=["Example XNAT catalog"], description=["This is an example XNAT catalog description"])
     return catalog
 
 
 @pytest.fixture()
 def mock_dataset():
-    dataset = DCATDataset(title=['test project'], description=['test description'])
+    dataset = DCATDataset(title=["test project"], description=["test description"])
     return dataset
 
 
@@ -66,7 +66,7 @@ def test_empty_xnat(session, empty_graph: Graph, config: Dict[str, Any]):
     """Test case for an XNAT with no projects at all"""
     # XNATSession is a key-value store so pretend it is a Dict
     session.projects = {}
-    session.url_for.return_value = "https://xnat.bmia.nl"
+    session.url_for.return_value = "https://example.com"
 
     empty_graph = empty_graph.parse(source="tests/references/empty_xnat.ttl")
 
@@ -196,9 +196,9 @@ def test_xnat_to_rdf(xnat_list_datasets, xnat_to_DCATCatalog, session, mock_data
     xnat_to_DCATCatalog.return_value = mock_catalog
 
     session.projects = {}
-    session.url_for.return_value = "https://example.com/catalog"
+    session.url_for.return_value = "https://example.com"
 
-    xnat_list_datasets.return_value = [(mock_dataset, URIRef("http://example.com/dataset"))]
+    xnat_list_datasets.return_value = [(mock_dataset, URIRef("https://example.com/dataset"))]
 
     result_graph = xnat_to_RDF(session, config)
     reference_graph = empty_graph.parse(source="tests/references/minimal_catalog_dataset.ttl")

--- a/tests/test_dcat_serializer.py
+++ b/tests/test_dcat_serializer.py
@@ -138,9 +138,6 @@ def test_no_keywords(project, empty_graph: Graph, config: Dict[str, Any]):
     dcat, uri = xnat_to_DCATDataset(project, config)
     gen = dcat.to_graph(uri)
 
-    print(empty_graph.serialize())
-    print(gen.serialize())
-
     assert to_isomorphic(empty_graph) == to_isomorphic(gen)
 
 

--- a/tests/test_dcat_serializer.py
+++ b/tests/test_dcat_serializer.py
@@ -1,5 +1,4 @@
 import pathlib
-from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -161,9 +160,9 @@ def test_project_elligiblity(xnat_private_project, _check_optin_optout, project,
 @patch("img2catalog.xnat_parser.xnat_to_DCATDataset")
 def test_xnat_lister(xnat_to_DCATDataset, _check_elligibility_project):
     class SimpleProject:
-        def __init__(self, id):
+        def __init__(self, project_id):
             self.id = None
-            self.name = id
+            self.name = project_id
 
     # xnat_list_datasets
     session = MagicMock(spec=xnat.session.XNATSession)

--- a/tests/test_fdpclient.py
+++ b/tests/test_fdpclient.py
@@ -100,13 +100,13 @@ def test_fdp_node_removal():
 @patch("SPARQLWrapper.SPARQLWrapper.queryAndConvert")
 def test_subject_query_success(queryAndConvert, setQuery):
     expected_decoded_json = {
-        'head': {'vars': ['subject']},
-        'results': {
-            'bindings': [
+        "head": {"vars": ["subject"]},
+        "results": {
+            "bindings": [
                 {
-                    'subject': {
-                        'type': 'uri',
-                        'value': "http://example.com/dataset",
+                    "subject": {
+                        "type": "uri",
+                        "value": "http://example.com/dataset",
                     }
                 }
             ]
@@ -133,8 +133,8 @@ WHERE {
 @patch("SPARQLWrapper.SPARQLWrapper.queryAndConvert")
 def test_subject_query_empty(queryAndConvert, setQuery):
     expected_decoded_json = {
-        'head': {'vars': ['subject']},
-        'results': {'bindings': []},
+        "head": {"vars": ["subject"]},
+        "results": {"bindings": []},
     }
     queryAndConvert.return_value = expected_decoded_json
 
@@ -146,19 +146,19 @@ def test_subject_query_empty(queryAndConvert, setQuery):
 @patch("SPARQLWrapper.SPARQLWrapper.queryAndConvert")
 def test_subject_query_multiple(queryAndConvert):
     expected_decoded_json = {
-        'head': {'vars': ['subject']},
-        'results': {
-            'bindings': [
+        "head": {"vars": ["subject"]},
+        "results": {
+            "bindings": [
                 {
-                    'subject': {
-                        'type': 'uri',
-                        'value': "http://example.com/dataset1",
+                    "subject": {
+                        "type": "uri",
+                        "value": "http://example.com/dataset1",
                     }
                 },
                 {
-                    'subject': {
-                        'type': 'uri',
-                        'value': "http://example.com/dataset2",
+                    "subject": {
+                        "type": "uri",
+                        "value": "http://example.com/dataset2",
                     }
                 },
             ]
@@ -174,13 +174,13 @@ def test_subject_query_multiple(queryAndConvert):
 @patch("SPARQLWrapper.SPARQLWrapper.queryAndConvert")
 def test_subject_query_typeerror(queryAndConvert):
     expected_decoded_json = {
-        'head': {'vars': ['subject']},
-        'results': {
-            'bindings': [
+        "head": {"vars": ["subject"]},
+        "results": {
+            "bindings": [
                 {
-                    'subject': {
-                        'type': 'literal',
-                        'value': "incorrect_result",
+                    "subject": {
+                        "type": "literal",
+                        "value": "incorrect_result",
                     }
                 }
             ]

--- a/tests/test_fdpclient.py
+++ b/tests/test_fdpclient.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -5,21 +6,42 @@ import requests
 from rdflib import Graph, URIRef
 from rdflib.compare import to_isomorphic
 
-from img2catalog.fdpclient import FDPClient, FDPSPARQLClient, remove_node_from_graph
+from img2catalog.fdpclient import FDPClient, FDPSPARQLClient, add_or_update_dataset, remove_node_from_graph
 
 
 @pytest.fixture
 def fdp_client_mock(requests_mock):
-    requests_mock.post("http://fdp.example.com/tokens", json={"token": "1234abcd"})
-    fdp_client = FDPClient("http://fdp.example.com", "user@example.com", "pass")
+    requests_mock.post("https://fdp.example.com/tokens", json={"token": "1234abcd"})
+    requests_mock.put(
+        "https://fdp.example.com/dataset/12345678/meta/state",
+    )
+    requests_mock.put(
+        "https://fdp.example.com/dataset/12345678",
+    )
+    requests_mock.post(
+        "https://fdp.example.com/dataset",
+        status_code=201,
+        headers={"Location": "https://fdp.example.com/dataset/12345678"},
+        body=open(file="tests/references/fdp_dataset.ttl", mode="rb"),
+    )
+    requests_mock.post(
+        "https://fdp.example.com/catalog",
+        status_code=201,
+        headers={"Location": "https://fdp.example.com/catalog/87654321"},
+    )
+    requests_mock.post(
+        "https://fdp.example.com/distribution",
+        status_code=201,
+        headers={"Location": "https://fdp.example.com/distribution/abcdefgh"},
+    )
+    fdp_client = FDPClient("https://fdp.example.com", "user@example.com", "pass")
 
     return fdp_client
 
 
 def test_fdp_login(requests_mock):
-    requests_mock.post("http://fdp.example.com/tokens", json={"token": "1234abcd"})
-
-    fdp_client = FDPClient("http://fdp.example.com", "user@example.com", "pass")
+    requests_mock.post("https://fdp.example.com/tokens", json={"token": "1234abcd"})
+    fdp_client = FDPClient("https://fdp.example.com", "user@example.com", "pass")
 
     assert requests_mock.call_count == 1
     assert requests_mock.last_request.json() == {"email": "user@example.com", "password": "pass"}
@@ -33,11 +55,7 @@ def test_fdp_login_error(requests_mock):
         FDPClient("http://fdp.example.com", "wrong_email", "wrong_password")
 
 
-def test_fdp_publish(requests_mock, fdp_client_mock):
-    requests_mock.put(
-        "https://fdp.example.com/dataset/12345678/meta/state",
-    )
-
+def test_fdp_publish(requests_mock, fdp_client_mock: FDPClient):
     fdp_client_mock.publish_record("https://fdp.example.com/dataset/12345678")
 
     assert requests_mock.call_count == 2
@@ -46,44 +64,60 @@ def test_fdp_publish(requests_mock, fdp_client_mock):
 
 
 @pytest.mark.parametrize("metadata_type", ["dataset", "catalog", "distribution"])
-def test_fdp_post_serialised(requests_mock, fdp_client_mock, metadata_type):
-    requests_mock.post(f"http://fdp.example.com/{metadata_type}", text="")
+def test_fdp_post_serialised(
+    requests_mock,
+    fdp_client_mock: FDPClient,
+    metadata_type,
+):
+    requests_mock.post(f"https://fdp.example.com/{metadata_type}", text="")
 
     metadata = MagicMock(spec=Graph)
     metadata.serialize.return_value = ""
     # Ensure it's valid? Enforce lowercase?
     fdp_client_mock.post_serialized(metadata_type, metadata)
 
-    assert requests_mock.last_request.url == f"http://fdp.example.com/{metadata_type}"
+    assert requests_mock.last_request.url == f"https://fdp.example.com/{metadata_type}"
     assert requests_mock.last_request.headers["Content-Type"] == "text/turtle"
     assert requests_mock.last_request.headers["Authorization"] == "Bearer 1234abcd"
+    assert requests_mock.last_request.method == "POST"
+    metadata.serialize.assert_called_once_with(format="turtle")
+
+
+def test_fdp_update_serialised(requests_mock, fdp_client_mock: FDPClient):
+    requests_mock.put("http://fdp.example.com/dataset/test", text="")
+
+    metadata = MagicMock(spec=Graph)
+    metadata.serialize.return_value = ""
+    # Ensure it's valid? Enforce lowercase?
+    fdp_client_mock.update_serialized("http://fdp.example.com/dataset/test", metadata)
+
+    assert requests_mock.last_request.url == "http://fdp.example.com/dataset/test"
+    assert requests_mock.last_request.headers["Content-Type"] == "text/turtle"
+    assert requests_mock.last_request.headers["Authorization"] == "Bearer 1234abcd"
+    assert requests_mock.last_request.method == "PUT"
     metadata.serialize.assert_called_once_with(format="turtle")
 
 
 # @pytest.mark.repeat(1)
-@patch("img2catalog.fdpclient.FDPClient.post_serialized")
-@patch("img2catalog.fdpclient.FDPClient.publish_record")
-def test_fdp_create_and_publish(publish_record, post_serialized, requests_mock, fdp_client_mock):
-    requests_mock.post("http://fdp.example.com/dataset", text="")
+# @patch("img2catalog.fdpclient.FDPClient.post_serialized")
+# @patch("img2catalog.fdpclient.FDPClient.publish_record")
+# publish_record, post_serialized, requests_mock
+def test_fdp_create_and_publish(requests_mock, fdp_client_mock):
     empty_graph = Graph()
 
-    # load the reference file and return it as post_response text with code 201 ('Created')
-    # The FDP reference implementation returns the new identifier in HTTP location header
-    fdp_response = requests.Response()
-    fdp_response.status_code = 201
-    fdp_response.headers = {"Location": "http://fdp.example.com/dataset/f1bcfd31-397e-4955-930c-663df8c2d9bf"}
-    # requests expects a binary response content, not a string
-    with open(file="tests/references/fdp_dataset.ttl", mode="rb") as f:
-        fdp_response._content = f.read()
-
-    post_serialized.return_value = fdp_response
-
-    fdp_client_mock.create_and_publish("dataset", empty_graph)
-
-    publish_record.assert_called_once_with(
-        URIRef("http://fdp.example.com/dataset/f1bcfd31-397e-4955-930c-663df8c2d9bf")
+    assert fdp_client_mock.create_and_publish("dataset", empty_graph) == URIRef(
+        "https://fdp.example.com/dataset/12345678"
     )
-    post_serialized.assert_called_once_with(resource_type="dataset", metadata=empty_graph)
+    # Test if dataset is pushed correctly
+    assert requests_mock.request_history[-2].url == "https://fdp.example.com/dataset"
+    assert requests_mock.request_history[-2].headers["Content-Type"] == "text/turtle"
+    assert requests_mock.request_history[-2].method == "POST"
+
+    # Test if dataset is actually published
+    assert requests_mock.last_request.url == "https://fdp.example.com/dataset/12345678/meta/state"
+    assert requests_mock.last_request.headers["Content-Type"] == "application/json"
+    assert requests_mock.last_request.method == "PUT"
+    assert requests_mock.last_request.json() == {"current": "PUBLISHED"}
 
 
 def test_fdp_node_removal():
@@ -191,3 +225,53 @@ def test_subject_query_typeerror(queryAndConvert):
     t = FDPSPARQLClient("https://example.com")
     with pytest.raises(TypeError):
         t.find_subject("https://example.com/dataset", "https://example.com")
+
+
+# Not using the above FDP client here, easier to check if the related function calls in the client
+# are made. We can assume those calls are correct as they are tested above
+def test_dataset_updater_nomatch():
+    sparqlclient = MagicMock(spec=FDPSPARQLClient)
+    fdpclient = MagicMock(spec=FDPClient)
+    metadata = Graph()
+    dataset_identifier = "https://example.com/dataset"
+    catalog_uri = "https://fdp.example.com/catalog/123"
+
+    # No match found
+    sparqlclient.find_subject.return_value = None
+
+    add_or_update_dataset(metadata, fdpclient, dataset_identifier, catalog_uri, sparqlclient)
+
+    sparqlclient.find_subject.assert_called_once_with(dataset_identifier, catalog_uri)
+    fdpclient.create_and_publish.assert_called_once_with("dataset", metadata)
+    fdpclient.update_serialized.assert_not_called()
+
+
+def test_dataset_updater_match():
+    sparqlclient = MagicMock(spec=FDPSPARQLClient)
+    fdpclient = MagicMock(spec=FDPClient)
+    metadata = Graph()
+    dataset_identifier = "https://example.com/dataset"
+    catalog_uri = "https://fdp.example.com/catalog/123"
+
+    subject_uri = "https://fdp.example.com/dataset/456"
+    sparqlclient.find_subject.return_value = subject_uri
+
+    add_or_update_dataset(metadata, fdpclient, dataset_identifier, catalog_uri, sparqlclient)
+
+    sparqlclient.find_subject.assert_called_once_with(dataset_identifier, catalog_uri)
+    fdpclient.create_and_publish.assert_not_called()
+    fdpclient.update_serialized.assert_called_once_with(subject_uri, metadata)
+
+
+def test_dataset_updater_invalid():
+    sparqlclient = MagicMock(spec=FDPSPARQLClient)
+    fdpclient = MagicMock(spec=FDPClient)
+    metadata = Graph()
+    dataset_identifier = None
+    catalog_uri = "https://fdp.example.com/catalog/123"
+
+    add_or_update_dataset(metadata, fdpclient, dataset_identifier, catalog_uri, sparqlclient)
+
+    fdpclient.create_and_publish.assert_called_once_with("dataset", metadata)
+    sparqlclient.find_subject.assert_not_called()
+    fdpclient.update_serialized.assert_not_called()

--- a/tests/test_fdpclient.py
+++ b/tests/test_fdpclient.py
@@ -47,6 +47,14 @@ def test_fdp_login(requests_mock):
     assert requests_mock.last_request.json() == {"email": "user@example.com", "password": "pass"}
     assert fdp_client.get_headers() == {"Authorization": "Bearer 1234abcd", "Content-Type": "text/turtle"}
 
+def test_fdp_login_trailing_slash(requests_mock):
+    requests_mock.post("https://fdp.example.com/tokens", json={"token": "1234abcd"})
+    fdp_client = FDPClient("https://fdp.example.com/", "user@example.com", "pass")
+
+    assert requests_mock.call_count == 1
+    assert requests_mock.last_request.json() == {"email": "user@example.com", "password": "pass"}
+    assert fdp_client.get_headers() == {"Authorization": "Bearer 1234abcd", "Content-Type": "text/turtle"}
+
 
 def test_fdp_login_error(requests_mock):
     requests_mock.post("http://fdp.example.com/tokens", status_code=403)

--- a/tests/test_fdpclient.py
+++ b/tests/test_fdpclient.py
@@ -1,5 +1,4 @@
-from typing import Literal
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -46,6 +45,7 @@ def test_fdp_login(requests_mock):
     assert requests_mock.call_count == 1
     assert requests_mock.last_request.json() == {"email": "user@example.com", "password": "pass"}
     assert fdp_client.get_headers() == {"Authorization": "Bearer 1234abcd", "Content-Type": "text/turtle"}
+
 
 def test_fdp_login_trailing_slash(requests_mock):
     requests_mock.post("https://fdp.example.com/tokens", json={"token": "1234abcd"})
@@ -171,9 +171,8 @@ WHERE {
     setQuery.assert_called_with(expected_query)
 
 
-@patch("SPARQLWrapper.SPARQLWrapper.setQuery")
 @patch("SPARQLWrapper.SPARQLWrapper.queryAndConvert")
-def test_subject_query_empty(queryAndConvert, setQuery):
+def test_subject_query_empty(queryAndConvert):
     expected_decoded_json = {
         "head": {"vars": ["subject"]},
         "results": {"bindings": []},

--- a/tests/test_fdpclient.py
+++ b/tests/test_fdpclient.py
@@ -3,8 +3,9 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import requests
 from rdflib import Graph, URIRef
+from rdflib.compare import to_isomorphic
 
-from img2catalog.fdpclient import FDPClient
+from img2catalog.fdpclient import FDPClient, remove_node_from_graph
 
 
 @pytest.fixture
@@ -83,3 +84,12 @@ def test_fdp_create_and_publish(publish_record, post_serialized, requests_mock, 
         URIRef("http://fdp.example.com/dataset/f1bcfd31-397e-4955-930c-663df8c2d9bf")
     )
     post_serialized.assert_called_once_with(resource_type="dataset", metadata=empty_graph)
+
+
+def test_fdp_node_removal():
+    reference_graph = Graph().parse("tests/references/empty_xnat.ttl")
+
+    graph_to_modify = Graph().parse("tests/references/minimal_catalog_dataset.ttl")
+    remove_node_from_graph(URIRef("https://example.com/dataset"), graph_to_modify)
+
+    assert to_isomorphic(reference_graph) == to_isomorphic(graph_to_modify)


### PR DESCRIPTION
As a data owner, I want to run the img2catalog tool at a certain time interval to update metadata. But I do not want duplicates in my FDP every time I run the tool. Therefore, img2catalog needs to be able to recognize a dataset is already in the FDP and update it instead of POSTing it.

Steps:
1. Use dcterms:identifier to add a unique identifier to a dcat:Dataset object (could do some hashing on the unique xnat id)
2. Run a SHACL query against FDP for above identifier to get an IRI of a Dataset if it already exists
3. If it doesn’t exist, use current workflow. Else update the existing IRI

Acceptance criteria:
*    dcterms:identifier can be reliably generated
*    shacl query can be run from FDP client
*    Datasets are updated
