### PR TITLE
Health-RI core implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
-## Unreleased
+## 0.5.0
+
+### Fixed
+
+* img2catalog now uses the latest [SeMPyRO](https://github.com/health-RI/sempyro). This changes
+the VCard definition used for contactpoint.
+
+## 0.4.0 - 2024-07-23
+
+### Added
+
+* Datasets can now be updated in a FAIR Data Point if it exposes a SPARQL endpoint
+* Automated releases straight from Github
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Health-RI/img2catalog/python-test-package.yml)
 ![Codecov](https://img.shields.io/codecov/c/github/Health-RI/img2catalog)
 
-This tool queries an XNAT instance and generates DCAT-AP 3.0 metadata. Every XNAT project is considered
-to be a separate Dataset. Only 'public' and 'protected' datasets are queried.
+This tool queries an XNAT instance and generates DCAT-AP 3.0 metadata. Every XNAT project is
+considered to be a separate Dataset. Only 'public' and 'protected' datasets are queried.
+
+The metadata is compliant with the [Health-RI core v1 specification](https://github.com/Health-RI/health-ri-metadata/).
+Some fields are still left as placeholders. These will be updated in due time.
 
 ## Installation
 
@@ -92,13 +95,12 @@ Options:
 
 An example configuration file `config.toml` is supplied with this project. By default, `img2catalog`
 will look for a configuration file in `~/.img2catalog/config.toml`. The tool will not create the file
-or folder if it does not exist, you will have to do so manually. If the file does not exist, the
-example file will be used.
+or folder if it does not exist, you will have to do so manually. If the file does not exist, a
+hard-coded example file will be used.
 
 A limited number of properties can be set in the configuration, including the title and name of the
 xnat (DCAT) catalog and the publisher of the catalog. A default contact point for datasets can also
 be provided and will be included in the Dataset properties.
-We are still working on adding more default values for certain DCAT properties to the configuration.
 
 There is limited support for using environment variables. For setting the XNAT server, variables
 `XNAT_HOST` or `XNATPY_HOST` can be used, with the latter taking preference. Authentication can be
@@ -107,10 +109,22 @@ provided in `XNAT_USER` and `XNAT_PASS`.
 Commandline arguments take precedence over environment variables. Environment variables take
 precedence over `.netrc` login.
 
+## Metadata
+
+THe current metadata complies to the Health-RI core v1 shapes. This is an extension of DCAT-AP,
+output of the tool is thus fully compliant with DCAT-AP. A few fields that cannot be extracted
+from XNAT, are set at a more global level. This includes *dcat:contactPoint*, *dcat:theme* and
+*dcat:publisher*. The value of those fields can be set in the configuration.
+
+A few fields are currently set with stub values. That includes the *dcterms:identifier* of the
+*creator*, the *dcterms:license*, and the *dcterms:issued* and *dcterms:modified* fields. We hope
+to be able to expand XNAT to include these fields as well.
+
 ## Inclusion and exclusion of projects
 
 By default, all public and protected projects are indexed. Private projects are *not* indexed, even
-if you provide user credentials that have relevant permissions for them.
+if you provide user credentials that have relevant permissions for them. We can make an override
+for this behavior, please file an issue if you'd like to see this changed.
 
 Further granularity can be provided by using keywords. There is functionality for an opt-in keyword
 and an opt-out keyword, though only one of these at the time. If an opt-in keyword is set, only
@@ -119,7 +133,7 @@ ignored. If an opt-out keyword is set, all projects except for those containing 
 keyword will be indexed. The keywords can be configured in either the settings or the CLI, see the
 example configuration file.
 
-Note that private projects will never be indexed, not even if an opt-in keyword is set in them.
+Note that private projects will currently not be indexed, not even if an opt-in keyword is set in them.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
   "pytest-cov",
   "pytest-click",
   "pytest-repeat",
+  "freezegun",
 ]
 
 [[tool.hatch.envs.test.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "tomli >= 1.10; python_version < '3.11'",
   "click >= 8.0.0",
   "click-option-group~=0.5.6",
-  "sempyro >=1.3.0",
+  "sempyro >=1.4.0",
   "sparqlwrapper~=2.0",
 ]
 
@@ -86,6 +86,8 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py38"
 line-length = 120
+
+[tool.ruff.lint]
 select = [
   "A",
   "ARG",
@@ -134,15 +136,15 @@ unfixable = [
   "F401",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["img2catalog"]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+[tool.ruff.lint.per-file-ignores]
+# Tests can use magic values, assertions, relative imports, and Mixed-Case arguments
+"tests/**/*" = ["PLR2004", "S101", "TID252", "N803"]
 
 [tool.coverage.run]
 source_pkgs = ["img2catalog", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,12 @@ classifiers = [
 ]
 dependencies = [
   "rdflib ~= 7.0.0",
-  "xnat ~= 0.5.2",
+  "xnat ~= 0.6",
   "tqdm>=4.21",
   "tomli >= 1.10; python_version < '3.11'",
   "click >= 8.0.0",
   "click-option-group~=0.5.6",
-  "sempyro >=1.2.1",
+  "sempyro >=1.3.0",
   "sparqlwrapper~=2.0",
 ]
 

--- a/src/img2catalog/configmanager.py
+++ b/src/img2catalog/configmanager.py
@@ -28,10 +28,22 @@ def example_standard_config() -> str:
 # optin = "include_catalog"
 # optout = "exclude_catalog"
 
+[dataset]
+# Theme should be Health, according to the EU Data Theme vocabulary
+theme = "http://publications.europa.eu/resource/authority/data-theme/HEAL"
+
+# Default License for datasets is "available upon reasonable request"
+# I can't find that, so putting a placeholder here
+license = "http://example.com/license#nolicense"
+
 [dataset.contact_point]
 # override = true
 full_name = "Example Data Management office"
 email = "datamanager@example.com"
+
+[dataset.publisher]
+name = ["Example publisher list",]
+identifier = "http://example.com"
 
 [catalog]
 title = "Example XNAT catalog"
@@ -39,7 +51,7 @@ description = "This is an example XNAT catalog description"
 
 [catalog.publisher]
 name = "Example publishing institution"
-homepage = "https://www.example.com"
+identifier = "http://www.example.com/institution#example"
 
 [distribution.default]
 title = "XNAT imaging distribution"

--- a/src/img2catalog/configmanager.py
+++ b/src/img2catalog/configmanager.py
@@ -50,7 +50,7 @@ title = "Example XNAT catalog"
 description = "This is an example XNAT catalog description"
 
 [catalog.publisher]
-name = "Example publishing institution"
+name = ["Example publishing institution",]
 identifier = "http://www.example.com/institution#example"
 
 [distribution.default]

--- a/src/img2catalog/xnat_parser.py
+++ b/src/img2catalog/xnat_parser.py
@@ -7,7 +7,7 @@ import datetime
 
 from rdflib import DCAT, DCTERMS, FOAF, Graph, URIRef
 from sempyro.hri_dcat.hri_dataset import HRIDataset
-from sempyro.dcat import DCATCatalog
+from sempyro.hri_dcat.hri_catalog import HRICatalog
 from sempyro.vcard import VCARD, VCard
 from sempyro.foaf import Agent
 
@@ -54,8 +54,8 @@ def xnat_to_DCATDataset(project: XNATBaseObject, config: Dict) -> Tuple[HRIDatas
 
     Returns
     -------
-    DCATDataset
-        DCATDataset object with fields filled in
+    HRIDataset
+        HRIDataset object with fields filled in
     URIRef
         Subject that could be used
     """
@@ -112,7 +112,7 @@ def xnat_to_DCATDataset(project: XNATBaseObject, config: Dict) -> Tuple[HRIDatas
     return project_dataset, URIRef(project_uri)
 
 
-def xnat_to_DCATCatalog(session: XNATSession, config: Dict) -> DCATCatalog:
+def xnat_to_DCATCatalog(session: XNATSession, config: Dict) -> HRICatalog:
     """Creates a DCAT-AP compliant Catalog from XNAT instance
 
     Parameters
@@ -124,12 +124,15 @@ def xnat_to_DCATCatalog(session: XNATSession, config: Dict) -> DCATCatalog:
 
     Returns
     -------
-    DCATCatalog
-        DCATCatalog object with fields populated
+    HRICatalog
+        HRICatalog object with fields populated
     """
-    catalog = DCATCatalog(
+    publisher_foaf = [Agent(**config['catalog']['publisher'])]
+
+    catalog = HRICatalog(
         title=[config["catalog"]["title"]],
         description=[config["catalog"]["description"]],
+        publisher=publisher_foaf,
     )
     return catalog
 

--- a/tests/example-config.toml
+++ b/tests/example-config.toml
@@ -24,7 +24,7 @@ title = "Example XNAT catalog"
 description = "This is an example XNAT catalog description"
 
 [catalog.publisher]
-name = "Example publishing institution"
+name = ["Example publishing institution",]
 identifier = "http://www.example.com/institution#example"
 
 [distribution.default]

--- a/tests/example-config.toml
+++ b/tests/example-config.toml
@@ -2,10 +2,22 @@
 # optin = "include_catalog"
 # optout = "exclude_catalog"
 
+[dataset]
+# Theme should be Health, according to the EU Data Theme vocabulary
+theme = "http://publications.europa.eu/resource/authority/data-theme/HEAL"
+
+# Default License for datasets is "available upon reasonable request"
+# I can't find that, so putting a placeholder here
+license = "http://example.com/license#nolicense"
+
 [dataset.contact_point]
 # override = true
 full_name = "Example Data Management office"
 email = "datamanager@example.com"
+
+[dataset.publisher]
+name = ["Example publisher list",]
+identifier = "http://example.com"
 
 [catalog]
 title = "Example XNAT catalog"
@@ -13,7 +25,7 @@ description = "This is an example XNAT catalog description"
 
 [catalog.publisher]
 name = "Example publishing institution"
-homepage = "https://www.example.com"
+identifier = "http://www.example.com/institution#example"
 
 [distribution.default]
 title = "XNAT imaging distribution"

--- a/tests/references/empty_xnat.ttl
+++ b/tests/references/empty_xnat.ttl
@@ -1,8 +1,11 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
 <https://example.com> a dcat:Catalog ;
     dcterms:title "Example XNAT catalog" ;
+    dcterms:publisher [ a foaf:Agent ;
+            dcterms:identifier "http://www.example.com/institution#example" ;
+            foaf:name "Example publishing institution" ] ;
     dcterms:description "This is an example XNAT catalog description" .
 

--- a/tests/references/minimal_dcat_catalog_dataset.ttl
+++ b/tests/references/minimal_dcat_catalog_dataset.ttl
@@ -1,12 +1,8 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
 <https://example.com> a dcat:Catalog ;
     dcterms:title "Example XNAT catalog" ;
-    dcterms:publisher [ a foaf:Agent ;
-            dcterms:identifier "http://www.example.com/institution#example" ;
-            foaf:name "Example publishing institution" ] ;
     dcterms:description "This is an example XNAT catalog description" ;
     dcat:dataset <https://example.com/dataset> .
 

--- a/tests/references/no_contact_email.ttl
+++ b/tests/references/no_contact_email.ttl
@@ -4,7 +4,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://localhost/data/archive/projects/test_img2catalog> a dcat:Dataset ;
-    dcterms:creator [ a vcard:VCard ;
+    dcterms:creator [ a vcard:Kind ;
             vcard:fn "prof. Albus Dumbledore" ;
             vcard:hasUID <http://example.com> ] ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
@@ -14,5 +14,5 @@
     dcat:keyword "dcat",
         "demo",
         "test" ;
-    dcat:contactPoint [ a vcard:VCard ;
+    dcat:contactPoint [ a vcard:Kind ;
             vcard:fn "Example Data Management office" ] .

--- a/tests/references/no_contactpoint.ttl
+++ b/tests/references/no_contactpoint.ttl
@@ -4,7 +4,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://localhost/data/archive/projects/test_img2catalog> a dcat:Dataset ;
-    dcterms:creator [ a vcard:VCard ;
+    dcterms:creator [ a vcard:Kind ;
             vcard:fn "prof. Albus Dumbledore" ;
             vcard:hasUID <http://example.com> ] ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;

--- a/tests/references/no_keyword.ttl
+++ b/tests/references/no_keyword.ttl
@@ -1,17 +1,24 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix v: <http://www.w3.org/2006/vcard/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://localhost/data/archive/projects/test_img2catalog> a dcat:Dataset ;
-    dcterms:creator [ a vcard:Kind ;
-            vcard:fn "prof. Albus Dumbledore" ;
-            vcard:hasUID <http://example.com/> ] ;
-    dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
+    dcterms:creator [ a foaf:Agent ;
+            foaf:name "prof. Albus Dumbledore" ;
+            dcterms:identifier "http://example.com" ] ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
-    dcterms:title "Basic test project to test the img2catalog" ;
     dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
-    dcat:contactPoint [ a vcard:Kind ;
-            vcard:fn "Example Data Management office" ;
-            vcard:hasEmail <mailto:datamanager@example.com> ;
-            vcard:hasUID <http://example.com/> ] .
+    dcterms:title "Basic test project to test the img2catalog" ;
+    dcterms:publisher [ a foaf:Agent ;
+            dcterms:identifier "http://example.com" ;
+            foaf:name "Example publisher list" ] ;
+    dcterms:issued "2024-04-01T00:00:00.00000"^^xsd:dateTime ;
+    dcterms:license <http://example.com/license#nolicense> ;
+    dcterms:modified "2024-04-01T00:00:00.00000"^^xsd:dateTime ;
+    dcat:theme <http://publications.europa.eu/resource/authority/data-theme/HEAL> ;
+    dcat:contactPoint [ a v:Kind ;
+            v:fn "Example Data Management office" ;
+            v:hasEmail <mailto:datamanager@example.com> ;
+            v:hasUID <http://example.com/>  ] .

--- a/tests/references/no_keyword.ttl
+++ b/tests/references/no_keyword.ttl
@@ -4,14 +4,14 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://localhost/data/archive/projects/test_img2catalog> a dcat:Dataset ;
-    dcterms:creator [ a vcard:VCard ;
+    dcterms:creator [ a vcard:Kind ;
             vcard:fn "prof. Albus Dumbledore" ;
             vcard:hasUID <http://example.com/> ] ;
     dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
     dcterms:title "Basic test project to test the img2catalog" ;
     dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
-    dcat:contactPoint [ a vcard:VCard ;
+    dcat:contactPoint [ a vcard:Kind ;
             vcard:fn "Example Data Management office" ;
             vcard:hasEmail <mailto:datamanager@example.com> ;
             vcard:hasUID <http://example.com/> ] .

--- a/tests/references/valid_project.ttl
+++ b/tests/references/valid_project.ttl
@@ -3,7 +3,7 @@
 @prefix v: <http://www.w3.org/2006/vcard/ns#> .
 
 <http://localhost/data/archive/projects/test_img2catalog> a dcat:Dataset ;
-    dcterms:creator [ a v:VCard ;
+    dcterms:creator [ a v:Kind ;
             v:fn "prof. Albus Dumbledore" ;
             v:hasUID <http://example.com/> ] ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
@@ -13,7 +13,7 @@
     dcat:keyword "dcat",
         "demo",
         "test" ;
-    dcat:contactPoint [ a v:VCard ;
+    dcat:contactPoint [ a v:Kind ;
             v:fn "Example Data Management office" ;
             v:hasEmail <mailto:datamanager@example.com> ;
             v:hasUID <http://example.com/>  ] .

--- a/tests/references/valid_project.ttl
+++ b/tests/references/valid_project.ttl
@@ -1,18 +1,26 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://localhost/data/archive/projects/test_img2catalog> a dcat:Dataset ;
-    dcterms:creator [ a v:Kind ;
-            v:fn "prof. Albus Dumbledore" ;
-            v:hasUID <http://example.com/> ] ;
+    dcterms:creator [ a foaf:Agent ;
+            foaf:name "prof. Albus Dumbledore" ;
+            dcterms:identifier "http://example.com" ] ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
     dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
     dcterms:title "Basic test project to test the img2catalog" ;
-    dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
     dcat:keyword "dcat",
         "demo",
         "test" ;
+    dcterms:publisher [ a foaf:Agent ;
+            dcterms:identifier "http://example.com" ;
+            foaf:name "Example publisher list" ] ;
+    dcterms:issued "2024-04-01T00:00:00.00000"^^xsd:dateTime ;
+    dcterms:license <http://example.com/license#nolicense> ;
+    dcterms:modified "2024-04-01T00:00:00.00000"^^xsd:dateTime ;
+    dcat:theme <http://publications.europa.eu/resource/authority/data-theme/HEAL> ;
     dcat:contactPoint [ a v:Kind ;
             v:fn "Example Data Management office" ;
             v:hasEmail <mailto:datamanager@example.com> ;

--- a/tests/references/valid_project_subject_replaced.ttl
+++ b/tests/references/valid_project_subject_replaced.ttl
@@ -3,7 +3,7 @@
 @prefix v: <http://www.w3.org/2006/vcard/ns#> .
 
 <http://example.com/newsubject> a dcat:Dataset ;
-    dcterms:creator [ a v:VCard ;
+    dcterms:creator [ a v:Kind ;
             v:fn "prof. Albus Dumbledore" ;
             v:hasUID <http://example.com/> ] ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
@@ -12,7 +12,7 @@
     dcat:keyword "dcat",
         "demo",
         "test" ;
-    dcat:contactPoint [ a v:VCard ;
+    dcat:contactPoint [ a v:Kind ;
             v:fn "Example Data Management office" ;
             v:hasEmail <mailto:datamanager@example.com> ;
             v:hasUID <http://example.com/>  ] .

--- a/tests/references/valid_project_subject_replaced.ttl
+++ b/tests/references/valid_project_subject_replaced.ttl
@@ -1,17 +1,26 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix v: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://example.com/newsubject> a dcat:Dataset ;
-    dcterms:creator [ a v:Kind ;
-            v:fn "prof. Albus Dumbledore" ;
-            v:hasUID <http://example.com/> ] ;
+    dcterms:creator [ a foaf:Agent ;
+            foaf:name "prof. Albus Dumbledore" ;
+            dcterms:identifier "http://example.com" ] ;
     dcterms:description "In this project, we test xnat and dcat and make sure a description appears." ;
-    dcterms:title "Basic test project to test the img2catalog" ;
     dcterms:identifier "http://localhost/data/archive/projects/test_img2catalog" ;
+    dcterms:title "Basic test project to test the img2catalog" ;
     dcat:keyword "dcat",
         "demo",
         "test" ;
+    dcterms:publisher [ a foaf:Agent ;
+            dcterms:identifier "http://example.com" ;
+            foaf:name "Example publisher list" ] ;
+    dcterms:issued "2024-04-01T00:00:00.00000"^^xsd:dateTime ;
+    dcterms:license <http://example.com/license#nolicense> ;
+    dcterms:modified "2024-04-01T00:00:00.00000"^^xsd:dateTime ;
+    dcat:theme <http://publications.europa.eu/resource/authority/data-theme/HEAL> ;
     dcat:contactPoint [ a v:Kind ;
             v:fn "Example Data Management office" ;
             v:hasEmail <mailto:datamanager@example.com> ;

--- a/tests/test_cliapp.py
+++ b/tests/test_cliapp.py
@@ -27,7 +27,7 @@ def empty_graph():
 def toml_patch_target():
     # Python 3.11 and up has tomllib built-in, for 3.10 and lower we use tomli which provides
     # the same functonality. We check if it's Python 3.10 or lower to patch the correct target.
-    if sys.version_info[0] == 3 and sys.version_info[1] <= 10:
+    if sys.version_info < (3, 11):
         return "tomli.load"
     else:
         return "tomllib.load"
@@ -223,11 +223,11 @@ def test_config_loader_error():
 @pytest.mark.parametrize("config_param", [None, TEST_CONFIG])
 @patch("img2catalog.configmanager.CONFIG_HOME_PATH", TEST_CONFIG)
 @patch("builtins.open")
-def test_config_dir(open, toml_patch_target, config_param):
+def test_config_dir(fileopen, toml_patch_target, config_param):
     with patch(toml_patch_target) as load:
         load_img2catalog_configuration(config_param)
         # Make sure the correct configuration is loaded
-        open.assert_called_once_with(TEST_CONFIG, "rb")
+        fileopen.assert_called_once_with(TEST_CONFIG, "rb")
         # Make sure the file de-serializer is called, not the string de-serializer
         load.assert_called_once()
 
@@ -241,7 +241,7 @@ def test_fdp_cli(connect, mock_FDPClient, xnat_to_FDP, isolated_cli_runner):
 
     mock_FDPClient.return_value = None
 
-    result = isolated_cli_runner.invoke(
+    isolated_cli_runner.invoke(
         cli_click,
         [
             "--verbose",
@@ -309,7 +309,7 @@ def test_output_project_file(
     # Always return a mock DCATDataset object and URI
     xnat_to_DCATDataset.return_value = (dummy_dcat_dataset, URIRef("http://example.com"))
 
-    result = isolated_cli_runner.invoke(
+    isolated_cli_runner.invoke(
         cli_click,
         ["--verbose", "-s", "http://example.com", "project", "test_project", "-o", "test_project.xml", "-f", "xml"],
     )

--- a/tests/test_dcat_serializer.py
+++ b/tests/test_dcat_serializer.py
@@ -14,6 +14,7 @@ except ModuleNotFoundError:
 import xnat
 from rdflib import DCAT, DCTERMS, Graph, URIRef
 from rdflib.compare import to_isomorphic
+from freezegun import freeze_time
 
 from img2catalog.xnat_parser import (
     VCARD,
@@ -75,6 +76,7 @@ def test_empty_xnat(session, empty_graph: Graph, config: Dict[str, Any]):
     assert to_isomorphic(expected) == to_isomorphic(empty_graph)
 
 
+@freeze_time("2024-04-01")
 @patch("xnat.core.XNATBaseObject")
 def test_valid_project(project, empty_graph: Graph, config: Dict[str, Any]):
     """Test if a valid project generates valid output"""
@@ -89,6 +91,9 @@ def test_valid_project(project, empty_graph: Graph, config: Dict[str, Any]):
     empty_graph = empty_graph.parse(source="tests/references/valid_project.ttl")
     dcat, uri = xnat_to_DCATDataset(project, config)
     gen = dcat.to_graph(uri)
+
+    print(gen.serialize())
+    print(empty_graph.serialize())
 
     assert to_isomorphic(empty_graph) == to_isomorphic(gen)
 

--- a/tests/test_dcat_serializer.py
+++ b/tests/test_dcat_serializer.py
@@ -12,9 +12,9 @@ except ModuleNotFoundError:
     import tomli as tomllib
 
 import xnat
+from freezegun import freeze_time
 from rdflib import DCAT, DCTERMS, Graph, URIRef
 from rdflib.compare import to_isomorphic
-from freezegun import freeze_time
 
 from img2catalog.xnat_parser import (
     VCARD,
@@ -92,9 +92,6 @@ def test_valid_project(project, empty_graph: Graph, config: Dict[str, Any]):
     dcat, uri = xnat_to_DCATDataset(project, config)
     gen = dcat.to_graph(uri)
 
-    print(gen.serialize())
-    print(empty_graph.serialize())
-
     assert to_isomorphic(empty_graph) == to_isomorphic(gen)
 
 
@@ -114,7 +111,7 @@ def test_empty_description(project, config: Dict[str, Any]):
 
 
 @patch("xnat.core.XNATBaseObject")
-def test_invalid_PI(project, config: Dict[str, Any]):
+def test_invalid_pi(project, config: Dict[str, Any]):
     """Make sure if PI field is invalid, an exception is raised"""
     project.name = "Basic test project to test the img2catalog"
     project.description = "In this project, we test xnat and dcat and make sure a description appears."
@@ -127,6 +124,7 @@ def test_invalid_PI(project, config: Dict[str, Any]):
         xnat_to_DCATDataset(project, config)
 
 
+@freeze_time("2024-04-01")
 @patch("xnat.core.XNATBaseObject")
 def test_no_keywords(project, empty_graph: Graph, config: Dict[str, Any]):
     """Valid project without keywords, make sure it is not defined in output"""
@@ -193,6 +191,7 @@ def test_xnat_lister(xnat_to_DCATDataset, _check_elligibility_project):
     assert xnat_to_DCATDataset.call_count == 3
 
 
+@freeze_time("2024-04-01")
 @patch("xnat.session.BaseXNATSession")
 @patch("img2catalog.xnat_parser.xnat_to_DCATCatalog")
 @patch("img2catalog.xnat_parser.xnat_list_datasets")

--- a/tests/test_dcat_serializer.py
+++ b/tests/test_dcat_serializer.py
@@ -204,6 +204,6 @@ def test_xnat_to_rdf(xnat_list_datasets, xnat_to_DCATCatalog, session, mock_data
     xnat_list_datasets.return_value = [(mock_dataset, URIRef("https://example.com/dataset"))]
 
     result_graph = xnat_to_RDF(session, config)
-    reference_graph = empty_graph.parse(source="tests/references/minimal_catalog_dataset.ttl")
+    reference_graph = empty_graph.parse(source="tests/references/minimal_dcat_catalog_dataset.ttl")
 
     assert to_isomorphic(result_graph) == to_isomorphic(reference_graph)

--- a/tests/test_optin_optout.py
+++ b/tests/test_optin_optout.py
@@ -31,7 +31,7 @@ def test_keyword_splitter(test_str, expected):
 @patch("xnat.core.XNATBaseObject")
 def test_no_optin_optout(project):
     project.keywords = "test demo optout_keyword"
-    config = {"img2catalog": dict()}
+    config = {"img2catalog": {}}
 
     # First test no config
     assert _check_optin_optout(project, config)

--- a/tests/test_private.py
+++ b/tests/test_private.py
@@ -1,7 +1,6 @@
 import logging
 
 import pytest
-from pytest import fixture
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR implements the full Health-RI core metadata scheme in img2catalog.

Some extra values that cannot be extracted from XNAT are set in the configuration now.

Note: issued/modified dates are still placeholder values.