### PR TITLE
Fix/small fixes

### DIFF
--- a/ext/xnat_custom_forms/health-ri-v2-dataset.json
+++ b/ext/xnat_custom_forms/health-ri-v2-dataset.json
@@ -1,5 +1,5 @@
 {
-  "title": "Health-RI v2 - form version 3",
+  "title": "Health-RI v2",
   "display": "form",
   "description": "",
   "settings": {},
@@ -18,9 +18,6 @@
           "key": "identifier",
           "type": "textfield",
           "label": "Identifier",
-          "validate": {
-            "required": true
-          },
           "description": "An unambiguous reference to the resource within a given context. Health-RI is currently working on a strategy for persistent identifiers for, among other things, datasets. Until a solid solution has been found, we propose the following temporary solution:\nIf your data is published in a repository, fill in with the provided DOI (Example: https://doi.org/10.34894/ZLOYOJ). If this 'Identifier' field is left blank, the URL to this XNAT dataset will be used as an identifier. Ensure that metadata is updated if your situation changes.",
           "input": true,
           "tableView": true
@@ -317,7 +314,6 @@
               "tableView": true,
               "placeholder": "Enter publisher type URI (e.g., http://purl.org/adms/publishertype/Company)",
               "validate": {
-                "required": true,
                 "pattern": "^http://purl\\.org/adms/publishertype/.+",
                 "patternMessage": "Value must be from the http://purl.org/adms/publishertype/ domain"
               },

--- a/src/img2catalog/inputs/xnat.py
+++ b/src/img2catalog/inputs/xnat.py
@@ -276,7 +276,7 @@ class XNATInput:
             
         try:
             # Retrieve custom form data from XNAT API
-            custom_fields_url = f"/xapi/custom-fields/projects/{project.name}/fields"
+            custom_fields_url = f"/xapi/custom-fields/projects/{project.id}/fields"
             response = project.xnat_session.get(custom_fields_url)
             
             if response.status_code != 200:

--- a/tests/test_inputs_xnat.py
+++ b/tests/test_inputs_xnat.py
@@ -524,7 +524,7 @@ def test_get_custom_form_metadata_success(project, xnatpy_mock: Mocker, xnatpy_c
         }
     }
     
-    project.name = "test_project"
+    project.id = "test_project"
     project.xnat_session = xnatpy_connection
     xnatpy_mock.get("/xapi/custom-fields/projects/test_project/fields", json=custom_form_response)
     


### PR DESCRIPTION
- The title in the JSON form definition changes from "Health-RI v2 - form version 3", used for testing, to "Health-RI v2"
- The URL to retrieve the custom forms should be based on the project ID not the project name. This has been changed.